### PR TITLE
Remove print()

### DIFF
--- a/src/simple_graph_sqlite/database.py
+++ b/src/simple_graph_sqlite/database.py
@@ -179,7 +179,6 @@ def find_node(identifier):
 
 
 def _parse_search_results(results, idx=0):
-    print(results)
     return [json.loads(item[idx]) for item in results]
 
 


### PR DESCRIPTION
I don't think this `print()` needs to be here seeing that the very results being printed are returned one line below, so if one wishes to print the results they can very easily, and if no printing is desired, no printing happens.